### PR TITLE
Power/Exponent not displaying in Windows Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <p>
-<image src="./res/banner.jpg"/>
+<image src="./res/banner.jpg"/><br>
 An application to convert infix to postfix and vice versa...</p>
 </div>
 
@@ -21,8 +21,9 @@ An application to convert infix to postfix and vice versa...</p>
 
 
 # Usage
-- To convert infix to postfix, run `infix-postfix --infix ${infix_expression}`
-- To convert postfix to infix, run `infix-postfix --postfix ${postfix_expression}`
+- To convert infix to postfix, run `infix-postfix --infix "${infix_expression}"`
+- To convert postfix to infix, run `infix-postfix --postfix "${postfix_expression}"`
+> NOTE : Double quotes ("") is must for writing the expression to get correct output..
 - To run this application in your own application or python script, run
  
 ```python

--- a/infix_postfix/infix_postfix.py
+++ b/infix_postfix/infix_postfix.py
@@ -35,7 +35,7 @@ def isHigherPrecedence(val1: str, val2: str) -> bool:
         if val2 in PRECEDENCE[i]:
             val2_index = i
     if val1_index != None and val2_index != None:
-        if val1_index > val2_index:
+        if val1_index > val2_index or (val1_index == 0 and val2_index == 0):
             return False
         else:
             return True

--- a/tests/test_infix_postfix.py
+++ b/tests/test_infix_postfix.py
@@ -18,6 +18,10 @@ class TestInfixPostFix(unittest.TestCase):
         self.assertEqual("AB+C*D/EF^+G/", postfix("((A+B)*C/D+E^F)/G"))
         self.assertEqual("ABCD+EF+*G/+*H*", postfix("A*(B+(C+D)*(E+F)/G)*H"))
         self.assertEqual("AB+S/E*", postfix("(A+B)/S*E"))
+        self.assertEqual("KL+MN*-OP^W*U/V/T*+QJA^^+",
+                         postfix("K+L-M*N+(O^P)*W/U/V*T+Q^J^A"))
+        self.assertEqual("ABC^^", postfix("A^B^C"))
+        self.assertEqual("XABC^^+", postfix("X+A^B^C"))
 
     def test_Postfix_to_Infix(self):
         self.assertEqual("((A+B)*C)/D", infix("AB+C*D/"))


### PR DESCRIPTION
Fixes #1
Added expanded condition for preceedence check in same operator as parameter.